### PR TITLE
Use the duration of each timing curve and frame rate to tune the values cached in KFPathInterpolator

### DIFF
--- a/android/keyframes/src/main/java/com/facebook/keyframes/model/KFAnimation.java
+++ b/android/keyframes/src/main/java/com/facebook/keyframes/model/KFAnimation.java
@@ -170,4 +170,14 @@ public class KFAnimation {
   public KeyFramedObject getAnimation() {
     return mKeyFramedAnimation;
   }
+
+  /**
+   * Updates this {@link KFAnimation} object with the frame rate of the entire animation. This
+   * allows the animation to update its {@link KeyFramedObject} with the right frame rate.
+   *
+   * @param frameRate {@code int} that specifies the frame rate of the entire animation
+   */
+  public void setFrameRate(int frameRate) {
+    mKeyFramedAnimation.updateWithFrameRate(frameRate);
+  }
 }

--- a/android/keyframes/src/main/java/com/facebook/keyframes/model/KFAnimationGroup.java
+++ b/android/keyframes/src/main/java/com/facebook/keyframes/model/KFAnimationGroup.java
@@ -8,6 +8,7 @@
 package com.facebook.keyframes.model;
 
 import com.facebook.keyframes.model.keyframedmodels.KeyFramedAnchorPoint;
+import com.facebook.keyframes.model.keyframedmodels.KeyFramedObject;
 import com.facebook.keyframes.util.AnimationHelper;
 import com.facebook.keyframes.util.ArgCheckUtil;
 import com.facebook.keyframes.util.ListHelper;
@@ -86,5 +87,25 @@ public class KFAnimationGroup {
       return null;
     }
     return (KeyFramedAnchorPoint) mAnchorPoint.getAnimation();
+  }
+
+  /**
+   * Updates this {@link KFAnimationGroup} with the frame rate of the entire animation. This
+   * allows the internal list of {@link KFAnimation}s to update with the right frame rate.
+   *
+   * @param frameRate {@code int} that specifies the frame rate of the entire animation
+   */
+  public void postProcess(int frameRate) {
+    if (getAnchorPoint() != null) {
+      mAnchorPoint.setFrameRate(frameRate);
+    }
+
+    if (mAnimations == null || mAnimations.isEmpty()) {
+      return;
+    }
+
+    for (int i = 0; i < mAnimations.size(); i++) {
+      mAnimations.get(i).setFrameRate(frameRate);
+    }
   }
 }

--- a/android/keyframes/src/main/java/com/facebook/keyframes/model/KFFeature.java
+++ b/android/keyframes/src/main/java/com/facebook/keyframes/model/KFFeature.java
@@ -312,4 +312,32 @@ public class KFFeature {
   public String getConfigClassName() {
     return mClassName;
   }
+
+  /**
+   * Updates this {@link KFFeature} with the frame rate of the entire animation. This
+   * allows the constituent {@link KFAnimation}s to update with the right frame rate.
+   *
+   * @param frameRate {@code int} that specifies the frame rate of the entire animation
+   */
+  public void postProcess(int frameRate) {
+    // This logic needs some refactoring. Until then, please update each animation / KeyFramedObject
+    // here with the right frame rate, otherwise the animation will be really wonky because
+    // some objects won't have the right list of interpolators.
+    postProcessInternal(mStrokeWidthAnimation, frameRate);
+    postProcessInternal(mAnchorPoint, frameRate);
+    postProcessInternal(mOpacityAnimation, frameRate);
+    for (int i = 0; i < mFeatureMatrixAnimations.size(); i++) {
+      postProcessInternal(mFeatureMatrixAnimations.get(i), frameRate);
+    }
+    if (mKeyFramedPath != null) {
+      mKeyFramedPath.updateWithFrameRate(frameRate);
+    }
+  }
+
+  private static void postProcessInternal(KFAnimation animation, int frameRate) {
+    if (animation == null) {
+      return;
+    }
+    animation.setFrameRate(frameRate);
+  }
 }

--- a/android/keyframes/src/main/java/com/facebook/keyframes/model/KFImage.java
+++ b/android/keyframes/src/main/java/com/facebook/keyframes/model/KFImage.java
@@ -68,6 +68,12 @@ public class KFImage {
     public int key;
 
     public KFImage build() {
+      for (int i = 0; i < features.size(); i++) {
+        features.get(i).postProcess(frameRate);
+      }
+      for (int i = 0; i < animationGroups.size(); i++) {
+        animationGroups.get(i).postProcess(frameRate);
+      }
       return new KFImage(frameRate, frameCount, features, animationGroups, canvasSize, key);
     }
   }

--- a/android/keyframes/src/main/java/com/facebook/keyframes/model/keyframedmodels/KeyFrameAnimationHelper.java
+++ b/android/keyframes/src/main/java/com/facebook/keyframes/model/keyframedmodels/KeyFrameAnimationHelper.java
@@ -7,13 +7,13 @@
 
 package com.facebook.keyframes.model.keyframedmodels;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import android.view.animation.Interpolator;
 
 import com.facebook.keyframes.util.KFPathInterpolator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * A helper class to build a list of interpolators corresponding to a list of timing curves, for use
@@ -26,7 +26,10 @@ public class KeyFrameAnimationHelper {
    * returns an ImmutableList with a corresponding interpolator for each timing curve, in the same
    * order as supplied.
    */
-  public static List<Interpolator> buildInterpolatorList(float[][][] timingCurves) {
+  public static List<Interpolator> buildInterpolatorList(
+          float[][][] timingCurves,
+          int[] keyFrames,
+          int frameRate) {
     if (timingCurves == null) {
       return Collections.emptyList();
     }
@@ -38,9 +41,10 @@ public class KeyFrameAnimationHelper {
               influences[0][0],
               influences[0][1],
               influences[1][0],
-              influences[1][1]));
+              influences[1][1],
+              keyFrames[i + 1] - keyFrames[i],
+              frameRate));
     }
     return Collections.unmodifiableList(interpolatorList);
   }
-
 }

--- a/android/keyframes/src/main/java/com/facebook/keyframes/util/KFPathInterpolator.java
+++ b/android/keyframes/src/main/java/com/facebook/keyframes/util/KFPathInterpolator.java
@@ -30,19 +30,29 @@ import android.view.animation.Interpolator;
  */
 public class KFPathInterpolator implements Interpolator {
   /**
-   * Governs the accuracy of the approximation of the {@link Path}.
+   * Specifies the max FPS an animation can run at. This should ideally be 60, but we're using 90
+   * to give us some buffer (at the expense of caching more values in the mX and mY float arrays.
+   * This value is used to calculate the accuracy of the approximation of the {@link Path}.
    */
-  private static final float PRECISION = 0.03f;
+  private static final float MAX_FPS = 90;
   private final float[] mX;
   private final float[] mY;
 
-  public KFPathInterpolator(float controlX1, float controlY1, float controlX2, float controlY2) {
+  public KFPathInterpolator(
+          float controlX1,
+          float controlY1,
+          float controlX2,
+          float controlY2,
+          int duration,
+          int frameRate) {
     Path path = new Path();
     path.moveTo(0, 0);
     path.cubicTo(controlX1, controlY1, controlX2, controlY2, 1f, 1f);
     final PathMeasure pathMeasure = new PathMeasure(path, false /* forceClosed */);
     final float pathLength = pathMeasure.getLength();
-    final int numPoints = (int) (pathLength / PRECISION) + 1;
+    // This value is calculated based on how long this timing curve is and dictates how many
+    // values along the curve will be cached. This can be tuned further,
+    final int numPoints = (int) (((float) duration / frameRate) * MAX_FPS) + 1;
     mX = new float[numPoints];
     mY = new float[numPoints];
     final float[] position = new float[2];


### PR DESCRIPTION
Currently, we use a hard-coded PRECISION to determine the number of points to cache in KFPathInterpolator. This PR changes it so that the duration of the timing curve and the total frame rate of the animation are taken into account. In some cases (where the timing curve is really long) this leads to us caching higher values over a path, but in most other situations we end up caching far fewer values. 