### PR TITLE
Android: Update gradle and clean build setup

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.2-all.zip

--- a/android/keyframes-sample/build.gradle
+++ b/android/keyframes-sample/build.gradle
@@ -20,7 +20,6 @@ android {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.4.0'
     compile project(path: ':keyframes')
 }

--- a/android/keyframes-sample/build.gradle
+++ b/android/keyframes-sample/build.gradle
@@ -20,7 +20,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.4.0'
     compile project(path: ':keyframes')

--- a/android/keyframes/build.gradle
+++ b/android/keyframes/build.gradle
@@ -22,7 +22,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
 }

--- a/android/keyframes/src/main/AndroidManifest.xml
+++ b/android/keyframes/src/main/AndroidManifest.xml
@@ -1,7 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.keyframes">
-
-    <application/>
-
-</manifest>
+<manifest package="com.facebook.keyframes"/>


### PR DESCRIPTION
- Update Gradle to v3.2
- Update Android Gradle plugin to v2.2.2
- Removes unnecessary configuration in the `build.gradle` files and the `AndroidManifest.xml`