### PR TITLE
Podspec contains a typo making it not work

### DIFF
--- a/keyframes.podspec
+++ b/keyframes.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |spec|
   spec.summary          = 'Vector+keyframe rendering framework for iOS'
   spec.source           = { :git => 'https://github.com/facebookincubator/Keyframes.git', :tag => spec.version.to_s }
   spec.source_files     = 'ios/keyframes/src/**/*.{h,m,mm,cpp}'
-  spec.public_header_files = 'ios/keyframes/src/{DataModel/KFVector,Layers/KFVectorLayer. ParsingHelpers/KFVectorParsingHelper,Views/KFVectorView,Helpers/KFUtilities}.h'
+  spec.public_header_files = 'ios/keyframes/src/{DataModel/KFVector,Layers/KFVectorLayer,ParsingHelpers/KFVectorParsingHelper,Views/KFVectorView,Helpers/KFUtilities}.h'
   spec.requires_arc = true
   spec.social_media_url = 'https://twitter.com/fbOpenSource'
   spec.ios.deployment_target = '8.0'


### PR DESCRIPTION
Tried using this very cool project in an app by specifying this repo in a `Podfile` like this:

```
pod 'keyframes', :git => 'https://github.com/facebookincubator/Keyframes.git', :commit => '050821f91ed7b7d0dfa5c78832d542dcf150ba42'
```

Unfortunately there's a typo in `spec.public_header_files` so fi. `KFVectorLayer` is not correctly exposed. This PR fixes it.