### PR TITLE
Add a startAnimationFromProgress method

### DIFF
--- a/ios/keyframes/src/Layers/KFVectorLayer.h
+++ b/ios/keyframes/src/Layers/KFVectorLayer.h
@@ -33,6 +33,11 @@
 - (void)startAnimation;
 
 /**
+ * Call this method to start animation from a given progress, progress is in range of [0, 1].
+ */
+- (void)startAnimationFromProgress:(CGFloat)progress;
+
+/**
  * Call this method to pause vector animation. To resume, call resumeAnimation.
  */
 - (void)pauseAnimation;

--- a/ios/keyframes/src/Layers/KFVectorLayer.m
+++ b/ios/keyframes/src/Layers/KFVectorLayer.m
@@ -195,6 +195,13 @@
   self.beginTime = 0.0;
 }
 
+- (void)startAnimationFromProgress:(CGFloat)progress{
+    [self _resetAnimations];
+    self.speed = 1.0;
+    self.timeOffset = 0.0;
+    self.beginTime = progress * _faceModel.animationFrameCount / _faceModel.frameRate;
+}
+
 - (void)resumeAnimation
 {
   if (self.speed > 0) {


### PR DESCRIPTION
Hey! I found myself needing to start an animation from a random progress value (instead of from 0.0). 

I tried a combination of seekToProgress + start/resume but it didn't work.To support this use case I added a startAnimationFromProgress method. 

It seems like this need is shared by other users of the framework - see https://github.com/facebookincubator/Keyframes/issues/46

This was tested on device and works well.  