### PR TITLE
iOS: Add playOnce() for Parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Use `startAnimation`, `pauseAnimation`, `resumeAnimation` and `seekToProgress` o
 
 // Seek to a given progress in range [0, 1]
 [layer seekToProgress:0.5]; // seek to the mid point of the animation
+
+// Play the keyframe animation only once and stop it afterwards.
+[layer playOnce];
 ```
 
 ### Android Rendering

--- a/ios/keyframes/src/Layers/KFVectorLayer.h
+++ b/ios/keyframes/src/Layers/KFVectorLayer.h
@@ -33,18 +33,23 @@
 - (void)startAnimation;
 
 /**
- * Call this method to pause vector animation. To resume, call resumeAnimation.
+ * Call this method to pause the vector animation. To resume, call resumeAnimation.
  */
 - (void)pauseAnimation;
 
 /**
- * Call this method to resume vector animation.
+ * Call this method to resume the vector animation.
  */
 - (void)resumeAnimation;
 
 /**
- * Call this method seek the animation to a given progress, progress is in range of [0, 1].
+ * Call this method to seek the animation to a given progress, progress is in range of [0, 1].
  */
 - (void)seekToProgress:(CGFloat)progress;
+
+/**
+ * Call this method to play the keyframe animation only once and stop it afterwards.
+ */
+- (void)playOnce;
 
 @end

--- a/ios/keyframes/src/Layers/KFVectorLayer.m
+++ b/ios/keyframes/src/Layers/KFVectorLayer.m
@@ -202,6 +202,17 @@
   self.beginTime = 0.0;
 }
 
+- (void)playOnce
+{
+  [self startAnimation];
+    
+  dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * _faceModel.animationFrameCount / _faceModel.frameRate);
+  dispatch_after(delay, dispatch_get_main_queue(), ^(void) {
+    [self seekToProgress:1.0];
+    [self pauseAnimation];
+  });
+}
+
 - (void)resumeAnimation
 {
   if (self.speed > 0) {


### PR DESCRIPTION
This PR adds the `addOnce()` functionality from #94 for iOS as well. It's a common use-case for showcase animations, so I like the idea of a cross-platform API. Also fixing minor typo issues in the iOS docs.  :-)

The user should not pause and restart the animation, since my GCD timer waits for the finishing frames already, but people using this method instead of `startAnimation` will know that behavior. 

Feedback very welcome!