### PR TITLE
Rename Keyframes in podspec to match cocoapods.org

### DIFF
--- a/keyframes.podspec
+++ b/keyframes.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |spec|
-  spec.name             = 'Keyframes'
+  spec.name             = 'keyframes'
   spec.version          = '1.0.0'
   spec.license          = { :type => 'BSD', :file => 'LICENSE' }
   spec.homepage         = 'https://github.com/facebookincubator/Keyframes'


### PR DESCRIPTION
Currently its impossible to go from cocoapods to a hash based on git because the case doesn't match and since its already published as lower case keyframes I would suggest we update the podspec in the repo to match that.