### PR TITLE
Added reference to react-native-keyframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Existing implementations for mobile frameworks:
 
 | Framework             | Platform    | Author          | Link                                                            |
 |-----------------------|-------------|-----------------|-----------------------------------------------------------------|
+| React Native (imperative api)          | Android/IOS | [Tomas Roos](https://github.com/ptomasroos)| https://github.com/ptomasroos/react-native-keyframes/
 | Appcelerator Titanium | iOS         | [Hans Knoechel](https://github.com/hansemannn/)   | https://github.com/hansemannn/ti.keyframes                      |
 | Appcelerator Titanium | Android     | [Michael Gangolf](https://github.com/m1ga/) | https://github.com/m1ga/ti.keyframes                            |
 | React Native          | Android/iOS | [Underscope](https://github.com/underscopeio/)      | https://github.com/underscopeio/react-native-facebook-keyframes |


### PR DESCRIPTION
React Native Keyframes supports a imperative API to easier work with lifecycle events without using a state mgmt tool, used in a app with about 50K active users.