### PR TITLE
Fix NSAssert -> NSLog autocompletion-issue

### DIFF
--- a/ios/keyframes/src/Layers/KFVectorGradientFeatureLayer.m
+++ b/ios/keyframes/src/Layers/KFVectorGradientFeatureLayer.m
@@ -65,7 +65,7 @@
       [self _addRampEndPointAnimation:feature.gradientEffect.rampEnd];
     }
   } else {
-    NSAssert(@"Unknown gradient type passed in: %@", feature.gradientEffect.gradientTypeString);
+    NSLog(@"Unknown gradient type passed in: %@", feature.gradientEffect.gradientTypeString);
   }
 }
 


### PR DESCRIPTION
The error-log "Unknown gradient type passed in: xxxx" was written as an `NSAssert` which simply makes no sense and throws a warning in Xcode 9 when enabling the semantic warnings. This PR fixes this (minor) issue.