### PR TITLE
Fix links in mobile nav

### DIFF
--- a/_includes/nav/header_nav.html
+++ b/_includes/nav/header_nav.html
@@ -6,7 +6,11 @@
     <ul>
       {% for item in site.data.nav %}
       <li class="navItem">
-        <a href="{{ item.href }}"{% if item.category == "external" %} target="_blank"{% endif %}>{{ item.title }}</a>
+        {% if item.category == "external" %}
+          <a href="{{ item.href }}" target="_blank">{{ item.title }}</a>
+        {% else %}
+          <a href="{{ item.href | relative_url }}">{{ item.title }}</a>
+        {% endif %}
       </li>
       {% endfor %}
       {% if site.searchconfig %}


### PR DESCRIPTION
These links are broken on the mobile site layout:
```html
  <nav class="slidingNav">
    <ul>
      
      <li class="navItem">
        <a href="/docs/">Documentation</a>
      </li>
      
      <li class="navItem">
        <a href="/roadmap">Roadmap</a>
      </li>
      
      <li class="navItem">
        <a href="/faq">FAQ</a>
      </li>
```

They should be `/Keyframes/docs/`, etc.

Use `relative_url` so the URLs render properly